### PR TITLE
Remove some warnings when compiling in emacs-24

### DIFF
--- a/xterm-color.el
+++ b/xterm-color.el
@@ -99,7 +99,7 @@
 ;;
 ;;; Code:
 
-(require 'cl)
+(require 'cl-lib)
 
 (defgroup xterm-color nil
   "Translates ANSI control sequences to text properties."
@@ -236,7 +236,7 @@ if the property `xterm-color' is set. A possible way to install this would be:
   (remove-list-of-text-properties
    beg end (append
 	    font-lock-extra-managed-props
-	    (if font-lock-syntactic-keywords
+	    (if syntax-propertize-function
 		'(syntax-table font-lock-multiline)
 	      '(font-lock-multiline))))
   ;; Second pass: remove face property where xterm-color property is not present
@@ -252,7 +252,7 @@ if the property `xterm-color' is set. A possible way to install this would be:
 
 ;; The following is only needed in Emacs 23
 (defun xterm-color-unfontify-region-23 (beg end)
-  (when (boundp 'font-lock-syntactic-keywords)
+  (when (boundp 'syntax-propertize-function)
     (remove-text-properties beg end '(syntax-table nil)))
   (while (setq beg (text-property-not-all beg end 'face nil))
     (setq beg (or (text-property-not-all beg end 'xterm-color t)


### PR DESCRIPTION
I get some warnings when I build xterm-color on Emacs-24 (24.5, xterm-color comes from ELPA installed via Spacemacs). These changes satisfy the warnings and don't appear to break anything.

* Use `cl-lib` instead of `cl`
* Use `syntax-propertize-function` instead of `font-lock-syntactic-keywords`