### PR TITLE
Add support for 24-bit / full RGB color

### DIFF
--- a/README.org
+++ b/README.org
@@ -7,6 +7,7 @@ xterm-color.el is an ANSI control sequence to text-property translator
 * Features
 + Regular ANSI color support
 + XTERM 256 color support
++ Truecolor (24-bit) color support
 + AIXTERM bright foreground color
 + AIXTERM bright background color (since 1.8)
 + Use bold instead of bright (since 1.8)


### PR DESCRIPTION
Hi, thanks very much for this project. This PR adds support for 24-bit / full RGB ANSI color sequences. I have time available to do further work on this branch if that would help.

## Changes

1. Add support for 24-bit ANSI color sequences
2. Add an option allowing the user to request the colors as overlays instead of text properties.
3. ~~Make it possible for the user to specify that `'face` rather than `'font-lock-face` is used, even when `font-lock-mode` is active.~~

<details>

I'm using this to add support in magit for handling ANSI colors when the git output is redirected through a diff renderer such as [delta](https://github.com/dandavison/delta). To motivate the new options regarding overlays ~~and faces~~, it might be helpful to show the function that I am currently using in magit to apply `xterm-color` to the output received from git (via `delta`):

```emacs-lisp
(defun magit-diff-convert-ansi-colors--xterm-color (beg end)
  (require 'xterm-color)
  ;; save-excursion does not work here because xterm-color uses delete-and-extract-region
  (let ((pos (point)))
    (save-restriction
      (narrow-to-region beg end)
      (let ((inhibit-read-only t)
            (buffer-read-only nil))
        (xterm-color-colorize-buffer 'use-overlays)))
    (goto-char pos)))
```

</details>

## How do we know this is correct?

1. I've added a 24-bit color demo to `xterm-color-test`:
    <table><tr><td><img width=500px src="https://user-images.githubusercontent.com/52205/79007717-bcd25d00-7b29-11ea-9546-5699ffb6ca8f.png" alt="image" /></td></tr></table>

    It looks plausibly correct. Furthermore, the 24-bit colors in the demo are the same as in this [shell-script](https://github.com/gnachman/iTerm2/blob/master/tests/24-bit-color.sh). When the shell script is run in a terminal emulator (iTerm2), it appears the same:
    <table><tr><td><img width=500px src="https://user-images.githubusercontent.com/52205/79008397-52222100-7b2b-11ea-8d77-da87607bb2fd.png" alt="image" /></td></tr></table>

2. **What about the rest of the output in `xtem-color-test`**?<br>
   Here are screenshots of the test buffers on the two branches:
   <table><tr><td><img width=300px src="https://user-images.githubusercontent.com/52205/79022251-7ee63080-7b4b-11ea-9385-add419b0d855.png" alt="image" /></td></tr></table>
   <table><tr><td><img width=300px src="https://user-images.githubusercontent.com/52205/79022307-a0dfb300-7b4b-11ea-8fd9-69ccc06f5dd6.png" alt="image" /></td></tr></table>
   <table><tr><td><img width=300px src="https://user-images.githubusercontent.com/52205/79022383-c8368000-7b4b-11ea-9c22-641b14438beb.png" alt="image" /></td></tr></table>
   <table><tr><td><img width=300px src="https://user-images.githubusercontent.com/52205/79022451-ee5c2000-7b4b-11ea-93fe-b9eac1d87c4b.png" alt="image" /></td></tr></table>

3. **When `xterm-color` encounters a 24-bit ANSI sequence, the face cache key is > 32bits. Does that work in Emacs on a 32-bit architecture?**<br>
   I wasn't sure what to expect the answer to be here. What I have done is create an i686 ubuntu VM (`Linux ubuntu-xenial 4.4.0-177-generic #207-Ubuntu SMP Mon Mar 16 01:15:50 UTC 2020 i686 i686 i686 GNU/Linux`). In that VM Emacs 24.5.1 has `most-positive-fixnum` equal to 536870911 (versus 2305843009213693951 on my laptop). There were no errors when running `xterm-color-test` in Emacs 24.5.1 in that VM.

4. **Any issues byte compiling?**
   `xterm-color.el` byte-compiled with no errors and appears to work correctly when using the compiled file.

5. Finally, here's a screenshot of the new code handling some more complex patterns of ANSI sequences involving foreground and background colors (this is [delta](https://github.com/dandavison/delta) in magit, using xterm-color with this PR):
    <table><tr><td><img width=300px src="https://user-images.githubusercontent.com/52205/79015227-60c40480-7b3a-11ea-8eed-de774b991ff0.png" alt="image" /></td></tr></table>


## Has it impacted 256-color performance?

  Here's a shell script we can use to investigate that:
  ```emacs-lisp
  #!/usr/bin/env emacs --script
  (let ((package-load-list '((xterm-color t)))) (package-initialize))
  (require 'xterm-color)
  (let ((n (string-to-number (getenv "XTERM_COLOR_TEST_N_ITERATIONS"))))
    (dolist (i (number-sequence 0 (1- n)))
      (xterm-color-test)))
  ```

  The experiment I'm doing is looking at the impact of the proposed branch on the existing 256-color processing, so I'm comparing `master` (4b21b619841c93c4700039a93eb1881beee9248c) against this PR, but with the change to `xterm-color-test` reverted.

  The results show a very small decrease in speed: it looks like each call to `xterm-color-test` takes approximately 3ms longer.

EDIT: these timings are without byte compiling; see comment below for byte-compiled times.

  ```
   xterm-color  (master) for i in 1 2 3 4 5; do XTERM_COLOR_TEST_N_ITERATIONS=100 time bash -c "./time-xterm-color-test  2> /dev/null" ; done
         10.42 real        10.15 user         0.05 sys
         10.32 real        10.07 user         0.05 sys
         10.12 real         9.87 user         0.05 sys
         10.12 real         9.87 user         0.04 sys
         10.11 real         9.88 user         0.04 sys
   xterm-color  (master) git checkout -q 24-bit-color--with-no-change-to-xterm-color-test
   xterm-color  (24-bit-color--with-no-change-to-xterm-color-test) for i in 1 2 3 4 5; do XTERM_COLOR_TEST_N_ITERATIONS=100 time bash -c "./time-xterm-color-test  2> /dev/null" ; done
         10.71 real        10.45 user         0.05 sys
         10.46 real        10.22 user         0.04 sys
         10.45 real        10.22 user         0.05 sys
         10.42 real        10.21 user         0.04 sys
         10.40 real        10.15 user         0.05 sys
  ```
