### PR TITLE
New command xterm-color-apply-on-region

### DIFF
--- a/xterm-color.el
+++ b/xterm-color.el
@@ -742,6 +742,21 @@ prefix arg causes overlays to be used."
     (when read-only-p (read-only-mode 1))))
 
 ;;;###autoload
+(defun xterm-color-apply-on-region (beg end &optional use-overlays)
+  "Apply `xterm-color-filter' to current region.
+
+When called non-interactively, apply to region bounded by buffer
+positions BEG and END. See `xterm-color-colorize-buffer' for the
+meaning of USE-OVERLAYS."
+  (interactive "r")
+  (let ((pos (point)))
+    (save-restriction
+      (narrow-to-region beg end)
+      (let ((buffer-read-only nil))
+        (xterm-color-colorize-buffer use-overlays)))
+    (goto-char pos)))
+
+;;;###autoload
 (defun xterm-color-clear-cache ()
   "Clear xterm color face attribute cache.
 You may want to call this if you change `xterm-color-names' or


### PR DESCRIPTION
This PR adds a new command `xterm-color-apply-on-region`. In addition to being reasonable functionality to have, this mirrors the API of `ansi-color` (`ansi-color-apply-on-region`), which will help libraries migrating to `xterm-color`.

## How this was tested

Byte-compiled:
```
xterm-color-apply-on-region is an interactive compiled Lisp function
in ‘xterm-color.el’.
```

Use the interactive command on `xterm-color-test-raw` buffer with an active region:

![image](https://user-images.githubusercontent.com/52205/79493344-58af0d80-7fef-11ea-922b-1da591469dd0.png)

![image](https://user-images.githubusercontent.com/52205/79494182-92ccdf00-7ff0-11ea-8b56-1ee5d03d6fc2.png)


```
(get-text-property (point) 'face)
=> (:background "#192033")
(overlays-at (point))
=> nil
```



Use the function, with its `use-overlay` option: 
```
(xterm-color-apply-on-region (region-beginning) (region-end) 'use-overlay)
```

```
(get-text-property (point) 'face)
=> nil
(overlay-get (car (overlays-at (point))) 'face)
=> (:background "#192033")
```