### PR TITLE
use evaporate on overlays

### DIFF
--- a/xterm-color.el
+++ b/xterm-color.el
@@ -220,7 +220,8 @@ frame, overline.")
           (when current-value
             (let ((ov (make-overlay pos next-change)))
               (overlay-put ov face-prop current-value)
-              (overlay-put ov 'xterm-color t)))
+              (overlay-put ov 'xterm-color t)
+              (overlay-put ov 'evaporate t)))
           (goto-char next-change)))
       (remove-text-properties beg end (list 'xterm-color nil face-prop nil)))))
 


### PR DESCRIPTION
Hello, 

This PR adds 'evaporate on overlays created with `(xterm-color-colorize-buffer 'use-overlays)`.

The goal is to fix a performance issue on `magit-delta`. 
Each staging operation calls `xterm-color-colorize-buffer`, creating new overlays that replace previous diff content in the same buffer. Since overlays don't have the 'evaporate property, the number of overlays always increase instead of being cleaned up.

I have checked the other dependencies of xterm-color on melpa and `magit-delta` seems to be the only package using xterm-color with overlays.

I just realized that I can also fix the issue on magit-delta by iterating overlays and applying 'evaporate, but this may be a good optimization for other use cases.

What do you think?