### PR TITLE
Fix obsolete if-let warning on Emacs 31; add CI and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Minimum supported (Package-Requires) + latest stable + dev snapshot.
+        emacs_version:
+          - '25.1'
+          - '30.1'
+          - snapshot
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: purcell/setup-emacs@master
+        with:
+          version: ${{ matrix.emacs_version }}
+
+      - name: Byte-compile (warnings are errors)
+        run: |
+          emacs -Q --batch -L . \
+            --eval '(setq byte-compile-error-on-warn t)' \
+            -f batch-byte-compile xterm-color.el
+
+      - name: Load
+        run: emacs -Q --batch -L . --eval '(require (quote xterm-color))'

--- a/xterm-color.el
+++ b/xterm-color.el
@@ -350,48 +350,52 @@ going down SGR-LIST one element at a time."
                   (eq 2 (cl-second SGR-list)))          ; Truecolor (24-bit) FG color
              :skip 5)
             (when xterm-color--support-truecolor
-              (if-let ((r (cl-third SGR-list))
-                       (g (cl-fourth SGR-list))
-                       (b (cl-fifth SGR-list)))
-                  (if (or (> r 255) (> g 255) (> b 255))
-                      (xterm-color--message "SGR 38;2;%s;%s;%s exceeds range"
-                                            r g b)
-                    (set-truecolor! r g b xterm-color--current-fg))
-                (xterm-color--message "SGR 38;2;%s;%s;%s error, expected 38;2;R;G;B"
-                                      r g b))))
+              (let ((r (cl-third SGR-list))
+                    (g (cl-fourth SGR-list))
+                    (b (cl-fifth SGR-list)))
+                (if (and r g b)
+                    (if (or (> r 255) (> g 255) (> b 255))
+                        (xterm-color--message "SGR 38;2;%s;%s;%s exceeds range"
+                                              r g b)
+                      (set-truecolor! r g b xterm-color--current-fg))
+                  (xterm-color--message "SGR 38;2;%s;%s;%s error, expected 38;2;R;G;B"
+                                        r g b)))))
     (:match ((and (eq 38 (cl-first SGR-list))
                   (eq 5 (cl-second SGR-list)))
              :skip 3)                                   ; XTERM 256 FG color
-            (if-let ((color (cl-third SGR-list)))
-                (if (> color 255)
-                    (xterm-color--message "SGR 38;5;%s exceeds range" color)
-                  (set-f! color))
-              (xterm-color--message "SGR 38;5;%s error, expected 38;5;COLOR"
-                                    color)))
+            (let ((color (cl-third SGR-list)))
+              (if color
+                  (if (> color 255)
+                      (xterm-color--message "SGR 38;5;%s exceeds range" color)
+                    (set-f! color))
+                (xterm-color--message "SGR 38;5;%s error, expected 38;5;COLOR"
+                                      color))))
 
     (:match ((and (eq 48 (cl-first SGR-list))
                   (eq 2 (cl-second SGR-list)))          ; Truecolor (24-bit) BG color
              :skip 5)
             (when xterm-color--support-truecolor
-              (if-let ((r (cl-third SGR-list))
-                       (g (cl-fourth SGR-list))
-                       (b (cl-fifth SGR-list)))
-                  (if (or (> r 255) (> g 255) (> b 255))
-                      (xterm-color--message "SGR 48;2;%s;%s;%s exceeds range"
-                                            r g b)
-                    (set-truecolor! r g b xterm-color--current-bg))
-                (xterm-color--message "SGR 48;2;%s;%s;%s error, expected 48;2;R;G;B"
-                                      r g b))))
+              (let ((r (cl-third SGR-list))
+                    (g (cl-fourth SGR-list))
+                    (b (cl-fifth SGR-list)))
+                (if (and r g b)
+                    (if (or (> r 255) (> g 255) (> b 255))
+                        (xterm-color--message "SGR 48;2;%s;%s;%s exceeds range"
+                                              r g b)
+                      (set-truecolor! r g b xterm-color--current-bg))
+                  (xterm-color--message "SGR 48;2;%s;%s;%s error, expected 48;2;R;G;B"
+                                        r g b)))))
 
     (:match ((and (eq 48 (cl-first SGR-list))
                   (eq 5 (cl-second SGR-list)))
              :skip 3)                                   ; XTERM 256 BG color
-            (if-let ((color (cl-third SGR-list)))
-                (if (> color 255)
-                    (xterm-color--message "SGR 48;5;%s exceeds range" color)
-                  (set-b! color))
-              (xterm-color--message "SGR 48;5;%s error, expected 48;5;COLOR"
-                                    color)))
+            (let ((color (cl-third SGR-list)))
+              (if color
+                  (if (> color 255)
+                      (xterm-color--message "SGR 48;5;%s exceeds range" color)
+                    (set-b! color))
+                (xterm-color--message "SGR 48;5;%s error, expected 48;5;COLOR"
+                                      color))))
     (:match ((<= 90 elem 97))                           ; AIXTERM hi-intensity FG
             ;; Rather than setting bright, which would be wrong,
             ;; rescale color to fall within 8-15 so that it gets

--- a/xterm-color.el
+++ b/xterm-color.el
@@ -7,7 +7,7 @@
 ;; Version: 2.0
 ;; Author: xristos <xristos@sdf.org>
 ;; URL: https://github.com/atomontage/xterm-color
-;; Package-Requires: ((emacs "24.4"))
+;; Package-Requires: ((emacs "25.1"))
 ;; Keywords: faces
 
 ;; Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
## What

On Emacs 31.1 the byte-compiler reports `if-let` as obsolete (use
`if-let*`). This silences that warning in a backward-compatible way and
adds CI.

## Changes

**Fix the warning (commit 1).** Rather than switch to `if-let*` (which
requires Emacs 26.1 and would drop older-Emacs support), the four call
sites are rewritten with plain `let` + `if`, valid on every Emacs
version. Behaviour is unchanged: the bindings are pure list accessors
with no side effects, so binding them unconditionally and testing with
`and` is equivalent, and the error branches still reference the parsed
values.

**Add CI + dependabot (commit 2).** A GitHub Actions workflow
byte-compiles (warnings as errors) and loads the package across:
- the minimum supported Emacs (25.1),
- the latest stable (30.1),
- the development snapshot (which is where the `if-let` obsoletion
  surfaces, so it guards against regressions).

Dependabot keeps the workflow actions current.

This commit also corrects `Package-Requires` from `24.4` to `25.1`: the
package uses `defvar-local` (added in Emacs 25.1), so 24.4 was never
actually supported.

## Verification

All three CI jobs pass (byte-compile clean with warnings-as-errors, and
load): https://github.com/dannywillems/xterm-color/actions

Context: this is part of a small effort to clear byte-compile warnings
in widely-used Emacs packages and shore up their CI. Happy to adjust
anything (e.g. drop the `Package-Requires` change or the snapshot job)
to match your preferences.